### PR TITLE
Suppress and fix /w4 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ include("cmake/version.cmake")
 add_subdirectory("libbtf")
 
 if(BTF_ENABLE_TESTS)
+# Suppress C4702 for MSVC
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4702")
+endif()
+
   add_subdirectory("test")
 endif()
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -15,3 +15,16 @@ option(BTF_ENABLE_FUZZING "Set to true to enable fuzzing")
 set(CMAKE_EXPORT_COMPILE_COMMANDS true CACHE BOOL "Set to true to generate the compile_commands.json file (forced on)" FORCE)
 
 set(CMAKE_CXX_STANDARD 20)
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
+    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(COMMON_FLAGS -Wall -Wfatal-errors -DSIZEOF_VOID_P=8 -DSIZEOF_LONG=8)
+
+  set(RELEASE_FLAGS -O2 -flto -ffat-lto-objects)
+
+  set(DEBUG_FLAGS -O0 -g3 -fno-omit-frame-pointer)
+
+  set(SANITIZE_FLAGS -fsanitize=address -O1 -fno-omit-frame-pointer)
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20 /W4 /WX")
+endif ()

--- a/libbtf/btf_json.cpp
+++ b/libbtf/btf_json.cpp
@@ -136,6 +136,11 @@ void print_array_end(std::ostream &out) { out << "]"; }
   out << "}";                                                                  \
   }
 
+// Suppress C4456 on when using MSVC:
+// declaration of 'first' hides previous local declaration
+#pragma warning(push)
+#pragma warning(disable : 4456)
+
 void btf_type_to_json(const std::map<btf_type_id, btf_kind> &id_to_kind,
                       std::ostream &out) {
   std::function<void(btf_type_id, const btf_kind &)> print_btf_kind =
@@ -449,5 +454,7 @@ void btf_type_to_json(const std::map<btf_type_id, btf_kind> &id_to_kind,
   PRINT_JSON_ARRAY_END();
   PRINT_JSON_OBJECT_END();
 }
+
+#pragma warning(pop)
 
 } // namespace libbtf

--- a/libbtf/btf_map.cpp
+++ b/libbtf/btf_map.cpp
@@ -71,21 +71,21 @@ _get_map_definition_from_btf(const btf_type_data &btf_types,
 
   // Optional fields.
   if (key) {
-    size_t key_size = btf_types.get_size(key);
+    size_t key_size_in_bytes = btf_types.get_size(key);
     if (key_size > UINT32_MAX) {
       throw std::runtime_error("key size too large");
     }
-    map_definition.key_size = static_cast<uint32_t>(key_size);
+    map_definition.key_size = static_cast<uint32_t>(key_size_in_bytes);
   } else if (key_size) {
     map_definition.key_size = _value_from_BTF__uint(btf_types, key_size);
   }
 
   if (value) {
-    size_t value_size = btf_types.get_size(value);
+    size_t value_size_in_bytes = btf_types.get_size(value);
     if (value_size > UINT32_MAX) {
       throw std::runtime_error("value size too large");
     }
-    map_definition.value_size = static_cast<uint32_t>(value_size);
+    map_definition.value_size = static_cast<uint32_t>(value_size_in_bytes);
   } else if (value_size) {
     map_definition.value_size = _value_from_BTF__uint(btf_types, value_size);
   }
@@ -109,7 +109,6 @@ parse_btf_map_section(const btf_type_data &btf_data) {
   auto maps_section =
       btf_data.get_kind_type<btf_kind_data_section>(btf_data.get_id(".maps"));
 
-  size_t index = 0;
   for (const auto &var : maps_section.members) {
     map_definitions.push_back(_get_map_definition_from_btf(btf_data, var.type));
   }
@@ -184,7 +183,7 @@ btf_type_id build_btf_map(btf_type_data &btf_data,
 
   for (auto &member : map.members) {
     member.offset_from_start_in_bits = offset_in_bits;
-    offset_in_bits += btf_data.get_size(member.type) * 8;
+    offset_in_bits += static_cast<uint32_t>(btf_data.get_size(member.type) * 8);
   }
 
   map.size_in_bytes = offset_in_bits / 8;

--- a/libbtf/btf_write.cpp
+++ b/libbtf/btf_write.cpp
@@ -83,10 +83,10 @@ std::vector<std::byte> btf_write_types(const std::vector<btf_kind> &btf_kind) {
             btf_type.type = value.type;
           }
           if constexpr (btf_kind_traits<decltype(value)>::has_members) {
-            vlen = value.members.size();
+            vlen = static_cast<uint32_t>(value.members.size());
           }
           if constexpr (btf_kind_traits<decltype(value)>::has_parameters) {
-            vlen = value.parameters.size();
+            vlen = static_cast<uint32_t>(value.parameters.size());
           }
           if constexpr (btf_kind_traits<decltype(value)>::has_size_in_bytes) {
             btf_type.size = value.size_in_bytes;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -16,7 +16,13 @@
 #include "btf_parse.h"
 #include "btf_type_data.h"
 #include "btf_write.h"
+
+// Suppress some W4 warnings from the elfio library.
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#pragma warning(disable : 4458)
 #include "elfio/elfio.hpp"
+#pragma warning(pop)
 
 #define TEST_OBJECT_FILE_DIRECTORY "external/ebpf-samples/build/"
 #define TEST_SOURCE_FILE_DIRECTORY "external/ebpf-samples/src/"
@@ -147,6 +153,10 @@ void verify_line_info(const std::string &file) {
       [&](const std::string &section, uint32_t instruction_offset,
           const std::string &file_name, const std::string &source,
           uint32_t line_number, uint32_t column_number) {
+        // column_number is not used.
+        (void)column_number;
+        // instruction_offset is not used.
+        (void)instruction_offset;
         if (!source.empty()) {
           // Removing any trailing whitespace.
           std::string stripped_source =


### PR DESCRIPTION
Make narrowing more explicit.
Suppress warnings in external projects.