### PR TITLE
Simplify variant handling with visit

### DIFF
--- a/libbtf/btf_map.cpp
+++ b/libbtf/btf_map.cpp
@@ -191,7 +191,7 @@ btf_type_id build_btf_map(btf_type_data &btf_data,
   return btf_data.append(btf_kind_var{
       .name = map_definition.name,
       .type = btf_data.append(map),
-      .linkage = btf_kind_var::BTF_LINKAGE_STATIC,
+      .linkage = BTF_LINKAGE_STATIC,
   });
 }
 

--- a/libbtf/btf_parse.cpp
+++ b/libbtf/btf_parse.cpp
@@ -196,7 +196,7 @@ void btf_parse_types(const std::vector<std::byte> &btf,
 
   validate_range(btf, type_start, type_end);
 
-  btf_kind_null kind_null;
+  btf_kind_void kind_null;
   visitor(0, "void", {kind_null});
 
   for (offset = type_start; offset < type_end;) {

--- a/libbtf/btf_type_data.h
+++ b/libbtf/btf_type_data.h
@@ -35,7 +35,7 @@ public:
    */
   btf_type_data() {
     // Add the void type.
-    id_to_kind[0] = btf_kind_null{};
+    id_to_kind[0] = btf_kind_void{};
   }
 
   /**
@@ -114,7 +114,7 @@ private:
   std::map<std::string, btf_type_id> name_to_id;
 };
 
-LIBBTF_BTF_TYPE_DATA_GET_KIND_TYPE(BTF_KIND_NULL, btf_kind_null)
+LIBBTF_BTF_TYPE_DATA_GET_KIND_TYPE(BTF_KIND_VOID, btf_kind_void)
 LIBBTF_BTF_TYPE_DATA_GET_KIND_TYPE(BTF_KIND_INT, btf_kind_int)
 LIBBTF_BTF_TYPE_DATA_GET_KIND_TYPE(BTF_KIND_PTR, btf_kind_ptr)
 LIBBTF_BTF_TYPE_DATA_GET_KIND_TYPE(BTF_KIND_ARRAY, btf_kind_array)

--- a/libbtf/btf_write.cpp
+++ b/libbtf/btf_write.cpp
@@ -63,7 +63,7 @@ std::vector<std::byte> btf_write_types(const std::vector<btf_kind> &btf_kind) {
   };
 
   for (const auto &kind : btf_kind) {
-    if (kind.index() == BTF_KIND_NULL) {
+    if (kind.index() == BTF_KIND_VOID) {
       continue;
     }
     // Write common BTF type header.


### PR DESCRIPTION
Where possible, replace switch over kind.index with std::variant, where possible, to make code simpler and more readable.