### PR TITLE
Add support for correctly parsing prog array with static init

### DIFF
--- a/test/expected/map_in_map.h
+++ b/test/expected/map_in_map.h
@@ -2,16 +2,7 @@
 
 #pragma once
 
-typedef unsigned int __uint32_t;
-
-typedef __uint32_t uint32_t;
-
-struct {
-  int (*type)[2];
-  uint32_t *key;
-  uint32_t *value;
-  int (*max_entries)[1];
-} inner_map;
+typedef unsigned int uint32_t;
 
 struct {
   int (*type)[12];
@@ -24,6 +15,13 @@ struct {
     int (*max_entries)[1];
   } * values[0];
 } array_of_maps;
+
+struct {
+  int (*type)[2];
+  uint32_t *key;
+  uint32_t *value;
+  int (*max_entries)[1];
+} inner_map;
 
 int func(void* ctx);
 


### PR DESCRIPTION
Fix issue when parsing BPF_MAP_TYPE_PROG_ARRAY with __values macro.
Include updated ebpf_samples repo.