### PR TITLE
Switch to macos-latest

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -45,8 +45,8 @@ jobs:
       run: |
         sudo apt-get install -y lcov
 
-    - name: Install prerequisites - macos-11
-      if: inputs.platform == 'macos-11'
+    - name: Install prerequisites - macos-latest
+      if: inputs.platform == 'macos-latest'
       run: |
         brew install \
           cmake \
@@ -59,7 +59,7 @@ jobs:
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBTF_ENABLE_TESTS=TRUE -DBTF_WARNING_AS_ERROR=TRUE
 
     - name: Configure CMake
-      if: inputs.platform == 'ubuntu-22.04' || inputs.platform == 'macos-11'
+      if: inputs.platform == 'ubuntu-22.04' || inputs.platform == 'macos-latest'
       run: |
         if [ "${{inputs.enable_sanitizers}}" = "true" ]; then
           export SANITIZER_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -109,13 +109,13 @@ jobs:
   macos_release:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: macos-11
+      platform: macos-latest
       configuration: Release
 
   macos_debug:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: macos-11
+      platform: macos-latest
       configuration: Debug
 
   finish:


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow files, specifically `.github/workflows/Build.yml` and `.github/workflows/CICD.yml`. The changes primarily involve updating the macOS version used in the workflows from `macos-11` to `macos-latest`. This ensures that the workflows are always run on the latest stable version of macOS. 

Here are the key changes:

* [`.github/workflows/Build.yml`](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcL48-R49): Updated the `Install prerequisites` job and the `Configure CMake` job to run on `macos-latest` instead of `macos-11`. [[1]](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcL48-R49) [[2]](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcL62-R62)
* [`.github/workflows/CICD.yml`](diffhunk://#diff-fdc42f85e64d73f2d88830f87cfb3c6f32c93a440ed1aaaf6bfbcb8648fb9defL112-R118): Updated the `macos_release` and `macos_debug` jobs to use `macos-latest` instead of `macos-11`.