### PR TITLE
Support installation in upstreams

### DIFF
--- a/libbtf/CMakeLists.txt
+++ b/libbtf/CMakeLists.txt
@@ -17,4 +17,4 @@ add_library("libbtf" STATIC
     "btf_write.h"
 )
 
-target_include_directories("libbtf" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories("libbtf" INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")


### PR DESCRIPTION
Note that the include directories necessary to use libbtf are capable of being installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the visibility of include directories for the `libbtf` library to improve build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->