### PR TITLE
Allow parsing ringbuf in map

### DIFF
--- a/json/badhelpercall.json
+++ b/json/badhelpercall.json
@@ -1,0 +1,26 @@
+{
+  "btf_kinds": [
+    {
+      "id": 3,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 1,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    }
+  ]
+}

--- a/json/badmapptr.json
+++ b/json/badmapptr.json
@@ -1,0 +1,191 @@
+{
+  "btf_kinds": [
+    {
+      "id": 13,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "test_repro",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 12,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 11,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 14,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 10,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "test_map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 9,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 8,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 8,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/badrelo.json
+++ b/json/badrelo.json
@@ -1,0 +1,279 @@
+{
+  "btf_kinds": [
+    {
+      "id": 15,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 14,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 13,
+                "kind_type": "BTF_KIND_FWD",
+                "name": "ctx",
+                "is_struct": false
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 24,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "ebpf_map_update_elem",
+      "linkage": "BTF_FUNC_EXTERN",
+      "type": {
+        "id": 16,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "",
+            "type": {
+              "id": 17,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 18,
+                "kind_type": "BTF_KIND_FWD",
+                "name": "bpf_map",
+                "is_struct": false
+              }
+            }
+          },
+          {
+            "name": "",
+            "type": {
+              "id": 19,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 20,
+                "kind_type": "BTF_KIND_CONST",
+                "type": {
+                  "id": 0,
+                  "kind_type": "BTF_KIND_VOID"
+                }
+              }
+            }
+          },
+          {
+            "name": "",
+            "type": {
+              "id": 19,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 20,
+                "kind_type": "BTF_KIND_CONST",
+                "type": {
+                  "id": 0,
+                  "kind_type": "BTF_KIND_VOID"
+                }
+              }
+            }
+          },
+          {
+            "name": "",
+            "type": {
+              "id": 21,
+              "kind_type": "BTF_KIND_TYPEDEF",
+              "name": "uint64_t",
+              "type": {
+                "id": 22,
+                "kind_type": "BTF_KIND_TYPEDEF",
+                "name": "__uint64_t",
+                "type": {
+                  "id": 23,
+                  "kind_type": "BTF_KIND_INT",
+                  "name": "unsigned long long",
+                  "size_in_bytes": 8,
+                  "offset_from_start_in_bits": 0,
+                  "field_width_in_bits": 64,
+                  "is_signed": false,
+                  "is_char": false,
+                  "is_bool": false
+                }
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 25,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 11,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 10,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 2,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "int",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": true,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 6,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 0,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 8,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 9,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/byteswap.json
+++ b/json/byteswap.json
@@ -1,0 +1,40 @@
+{
+  "btf_kinds": [
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name": "ctx",
+                "is_struct": false
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    }
+  ]
+}

--- a/json/ctxoffset.json
+++ b/json/ctxoffset.json
@@ -1,0 +1,191 @@
+{
+  "btf_kinds": [
+    {
+      "id": 15,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 14,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 13,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 16,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 12,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 11,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 7,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 8,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 9,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 10,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 7,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 8,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 9,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 10,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/exposeptr.json
+++ b/json/exposeptr.json
@@ -1,0 +1,183 @@
+{
+  "btf_kinds": [
+    {
+      "id": 17,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 16,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 14,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 15,
+                "kind_type": "BTF_KIND_FWD",
+                "name": "ctx",
+                "is_struct": false
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 18,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 13,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 2,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "int",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": true,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 6,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint64_t",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint64_t",
+                        "type": {
+                          "id": 9,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned long long",
+                          "size_in_bytes": 8,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 64,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 10,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 11,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/exposeptr2.json
+++ b/json/exposeptr2.json
@@ -1,0 +1,193 @@
+{
+  "btf_kinds": [
+    {
+      "id": 20,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 19,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 17,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 18,
+                "kind_type": "BTF_KIND_FWD",
+                "name": "ctx",
+                "is_struct": false
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 21,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 16,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 15,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint64_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint64_t",
+                        "type": {
+                          "id": 8,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned long long",
+                          "size_in_bytes": 8,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 64,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 9,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 10,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 11,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 12,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 13,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 14,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/loop.json
+++ b/json/loop.json
@@ -1,0 +1,90 @@
+{
+  "btf_kinds": [
+    {
+      "id": 8,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "foo",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 6,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 2,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name": "test_md",
+                "size_in_bytes": 16,
+                "members": [
+                  {
+                    "name": "data_start",
+                    "offset_from_start_in_bits": 0,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "uint8_t",
+                        "type": {
+                          "id": 5,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned char",
+                          "size_in_bytes": 1,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 8,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_end",
+                    "offset_from_start_in_bits": 64,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "uint8_t",
+                        "type": {
+                          "id": 5,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned char",
+                          "size_in_bytes": 1,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 8,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 7,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    }
+  ]
+}

--- a/json/map_in_map.json
+++ b/json/map_in_map.json
@@ -1,0 +1,441 @@
+{
+  "btf_kinds": [
+    {
+      "id": 20,
+      "kind_type": "BTF_KIND_FUNCTION",
+      "name": "func",
+      "linkage": "BTF_LINKAGE_GLOBAL",
+      "type": {
+        "id": 19,
+        "kind_type": "BTF_KIND_FUNCTION_PROTOTYPE",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 18,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 21,
+      "kind_type": "BTF_KIND_DATA_SECTION",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 11,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "inner_map",
+            "linkage": "BTF_LINKAGE_GLOBAL",
+            "type": {
+              "id": 10,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 8,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 9,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 17,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "array_of_maps",
+            "linkage": "BTF_LINKAGE_GLOBAL",
+            "type": {
+              "id": 16,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 24,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 12,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 13,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 12,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 8,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 9,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "values",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 15,
+                    "kind_type": "BTF_KIND_ARRAY",
+                    "count_of_elements": 0,
+                    "element_type": {
+                      "id": 14,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 10,
+                        "kind_type": "BTF_KIND_STRUCT",
+                        "size_in_bytes": 32,
+                        "members": [
+                          {
+                            "name": "type",
+                            "offset_from_start_in_bits": 0,
+                            "type": {
+                              "id": 1,
+                              "kind_type": "BTF_KIND_PTR",
+                              "type": {
+                                "id": 3,
+                                "kind_type": "BTF_KIND_ARRAY",
+                                "count_of_elements": 2,
+                                "element_type": {
+                                  "id": 2,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "int",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": true,
+                                  "is_char": false,
+                                  "is_bool": false
+                                },
+                                "index_type": {
+                                  "id": 4,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "__ARRAY_SIZE_TYPE__",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": false,
+                                  "is_char": false,
+                                  "is_bool": false
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "name": "key",
+                            "offset_from_start_in_bits": 64,
+                            "type": {
+                              "id": 5,
+                              "kind_type": "BTF_KIND_PTR",
+                              "type": {
+                                "id": 6,
+                                "kind_type": "BTF_KIND_TYPEDEF",
+                                "name": "uint32_t",
+                                "type": {
+                                  "id": 7,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "unsigned int",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": false,
+                                  "is_char": false,
+                                  "is_bool": false
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "name": "value",
+                            "offset_from_start_in_bits": 128,
+                            "type": {
+                              "id": 5,
+                              "kind_type": "BTF_KIND_PTR",
+                              "type": {
+                                "id": 6,
+                                "kind_type": "BTF_KIND_TYPEDEF",
+                                "name": "uint32_t",
+                                "type": {
+                                  "id": 7,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "unsigned int",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": false,
+                                  "is_char": false,
+                                  "is_bool": false
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "name": "max_entries",
+                            "offset_from_start_in_bits": 192,
+                            "type": {
+                              "id": 8,
+                              "kind_type": "BTF_KIND_PTR",
+                              "type": {
+                                "id": 9,
+                                "kind_type": "BTF_KIND_ARRAY",
+                                "count_of_elements": 1,
+                                "element_type": {
+                                  "id": 2,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "int",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": true,
+                                  "is_char": false,
+                                  "is_bool": false
+                                },
+                                "index_type": {
+                                  "id": 4,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "__ARRAY_SIZE_TYPE__",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": false,
+                                  "is_char": false,
+                                  "is_bool": false
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "index_type": {
+                      "id": 4,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "__ARRAY_SIZE_TYPE__",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": false,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/map_in_map_anonymous.json
+++ b/json/map_in_map_anonymous.json
@@ -1,0 +1,306 @@
+{
+  "btf_kinds": [
+    {
+      "id": 19,
+      "kind_type": "BTF_KIND_FUNCTION",
+      "name": "func",
+      "linkage": "BTF_LINKAGE_GLOBAL",
+      "type": {
+        "id": 18,
+        "kind_type": "BTF_KIND_FUNCTION_PROTOTYPE",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 17,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 20,
+      "kind_type": "BTF_KIND_DATA_SECTION",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 24,
+          "type": {
+            "id": 16,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "outer_map",
+            "linkage": "BTF_LINKAGE_GLOBAL",
+            "type": {
+              "id": 15,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 24,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 12,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 7,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 8,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 9,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "values",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 14,
+                    "kind_type": "BTF_KIND_ARRAY",
+                    "count_of_elements": 0,
+                    "element_type": {
+                      "id": 10,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 11,
+                        "kind_type": "BTF_KIND_STRUCT",
+                        "size_in_bytes": 32,
+                        "members": [
+                          {
+                            "name": "type",
+                            "offset_from_start_in_bits": 0,
+                            "type": {
+                              "id": 12,
+                              "kind_type": "BTF_KIND_PTR",
+                              "type": {
+                                "id": 13,
+                                "kind_type": "BTF_KIND_ARRAY",
+                                "count_of_elements": 2,
+                                "element_type": {
+                                  "id": 2,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "int",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": true,
+                                  "is_char": false,
+                                  "is_bool": false
+                                },
+                                "index_type": {
+                                  "id": 4,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "__ARRAY_SIZE_TYPE__",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": false,
+                                  "is_char": false,
+                                  "is_bool": false
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "name": "key",
+                            "offset_from_start_in_bits": 64,
+                            "type": {
+                              "id": 7,
+                              "kind_type": "BTF_KIND_PTR",
+                              "type": {
+                                "id": 8,
+                                "kind_type": "BTF_KIND_TYPEDEF",
+                                "name": "uint32_t",
+                                "type": {
+                                  "id": 9,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "unsigned int",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": false,
+                                  "is_char": false,
+                                  "is_bool": false
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "name": "value",
+                            "offset_from_start_in_bits": 128,
+                            "type": {
+                              "id": 7,
+                              "kind_type": "BTF_KIND_PTR",
+                              "type": {
+                                "id": 8,
+                                "kind_type": "BTF_KIND_TYPEDEF",
+                                "name": "uint32_t",
+                                "type": {
+                                  "id": 9,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "unsigned int",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": false,
+                                  "is_char": false,
+                                  "is_bool": false
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "name": "max_entries",
+                            "offset_from_start_in_bits": 192,
+                            "type": {
+                              "id": 5,
+                              "kind_type": "BTF_KIND_PTR",
+                              "type": {
+                                "id": 6,
+                                "kind_type": "BTF_KIND_ARRAY",
+                                "count_of_elements": 1,
+                                "element_type": {
+                                  "id": 2,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "int",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": true,
+                                  "is_char": false,
+                                  "is_bool": false
+                                },
+                                "index_type": {
+                                  "id": 4,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "__ARRAY_SIZE_TYPE__",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": false,
+                                  "is_char": false,
+                                  "is_bool": false
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "index_type": {
+                      "id": 4,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "__ARRAY_SIZE_TYPE__",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": false,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/map_in_map_typedef.json
+++ b/json/map_in_map_typedef.json
@@ -1,0 +1,586 @@
+{
+  "btf_kinds": [
+    {
+      "id": 22,
+      "kind_type": "BTF_KIND_FUNCTION",
+      "name": "func",
+      "linkage": "BTF_LINKAGE_GLOBAL",
+      "type": {
+        "id": 21,
+        "kind_type": "BTF_KIND_FUNCTION_PROTOTYPE",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 20,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 23,
+      "kind_type": "BTF_KIND_DATA_SECTION",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 24,
+          "type": {
+            "id": 18,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "outer_map_1",
+            "linkage": "BTF_LINKAGE_GLOBAL",
+            "type": {
+              "id": 16,
+              "kind_type": "BTF_KIND_TYPEDEF",
+              "name": "outer_map_t",
+              "type": {
+                "id": 17,
+                "kind_type": "BTF_KIND_STRUCT",
+                "size_in_bytes": 24,
+                "members": [
+                  {
+                    "name": "type",
+                    "offset_from_start_in_bits": 0,
+                    "type": {
+                      "id": 1,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 3,
+                        "kind_type": "BTF_KIND_ARRAY",
+                        "count_of_elements": 12,
+                        "element_type": {
+                          "id": 2,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": true,
+                          "is_char": false,
+                          "is_bool": false
+                        },
+                        "index_type": {
+                          "id": 4,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "__ARRAY_SIZE_TYPE__",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "max_entries",
+                    "offset_from_start_in_bits": 64,
+                    "type": {
+                      "id": 5,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 6,
+                        "kind_type": "BTF_KIND_ARRAY",
+                        "count_of_elements": 1,
+                        "element_type": {
+                          "id": 2,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": true,
+                          "is_char": false,
+                          "is_bool": false
+                        },
+                        "index_type": {
+                          "id": 4,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "__ARRAY_SIZE_TYPE__",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "key",
+                    "offset_from_start_in_bits": 128,
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "uint32_t",
+                        "type": {
+                          "id": 9,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "values",
+                    "offset_from_start_in_bits": 192,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 0,
+                      "element_type": {
+                        "id": 10,
+                        "kind_type": "BTF_KIND_PTR",
+                        "type": {
+                          "id": 11,
+                          "kind_type": "BTF_KIND_TYPEDEF",
+                          "name": "inner_map_t",
+                          "type": {
+                            "id": 12,
+                            "kind_type": "BTF_KIND_STRUCT",
+                            "size_in_bytes": 32,
+                            "members": [
+                              {
+                                "name": "type",
+                                "offset_from_start_in_bits": 0,
+                                "type": {
+                                  "id": 13,
+                                  "kind_type": "BTF_KIND_PTR",
+                                  "type": {
+                                    "id": 14,
+                                    "kind_type": "BTF_KIND_ARRAY",
+                                    "count_of_elements": 2,
+                                    "element_type": {
+                                      "id": 2,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "int",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": true,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    },
+                                    "index_type": {
+                                      "id": 4,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "__ARRAY_SIZE_TYPE__",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": false,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "name": "key",
+                                "offset_from_start_in_bits": 64,
+                                "type": {
+                                  "id": 7,
+                                  "kind_type": "BTF_KIND_PTR",
+                                  "type": {
+                                    "id": 8,
+                                    "kind_type": "BTF_KIND_TYPEDEF",
+                                    "name": "uint32_t",
+                                    "type": {
+                                      "id": 9,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "unsigned int",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": false,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "name": "value",
+                                "offset_from_start_in_bits": 128,
+                                "type": {
+                                  "id": 7,
+                                  "kind_type": "BTF_KIND_PTR",
+                                  "type": {
+                                    "id": 8,
+                                    "kind_type": "BTF_KIND_TYPEDEF",
+                                    "name": "uint32_t",
+                                    "type": {
+                                      "id": 9,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "unsigned int",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": false,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "name": "max_entries",
+                                "offset_from_start_in_bits": 192,
+                                "type": {
+                                  "id": 5,
+                                  "kind_type": "BTF_KIND_PTR",
+                                  "type": {
+                                    "id": 6,
+                                    "kind_type": "BTF_KIND_ARRAY",
+                                    "count_of_elements": 1,
+                                    "element_type": {
+                                      "id": 2,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "int",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": true,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    },
+                                    "index_type": {
+                                      "id": 4,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "__ARRAY_SIZE_TYPE__",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": false,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "offset": 0,
+          "size": 24,
+          "type": {
+            "id": 19,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "outer_map_2",
+            "linkage": "BTF_LINKAGE_GLOBAL",
+            "type": {
+              "id": 16,
+              "kind_type": "BTF_KIND_TYPEDEF",
+              "name": "outer_map_t",
+              "type": {
+                "id": 17,
+                "kind_type": "BTF_KIND_STRUCT",
+                "size_in_bytes": 24,
+                "members": [
+                  {
+                    "name": "type",
+                    "offset_from_start_in_bits": 0,
+                    "type": {
+                      "id": 1,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 3,
+                        "kind_type": "BTF_KIND_ARRAY",
+                        "count_of_elements": 12,
+                        "element_type": {
+                          "id": 2,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": true,
+                          "is_char": false,
+                          "is_bool": false
+                        },
+                        "index_type": {
+                          "id": 4,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "__ARRAY_SIZE_TYPE__",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "max_entries",
+                    "offset_from_start_in_bits": 64,
+                    "type": {
+                      "id": 5,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 6,
+                        "kind_type": "BTF_KIND_ARRAY",
+                        "count_of_elements": 1,
+                        "element_type": {
+                          "id": 2,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": true,
+                          "is_char": false,
+                          "is_bool": false
+                        },
+                        "index_type": {
+                          "id": 4,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "__ARRAY_SIZE_TYPE__",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "key",
+                    "offset_from_start_in_bits": 128,
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "uint32_t",
+                        "type": {
+                          "id": 9,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "values",
+                    "offset_from_start_in_bits": 192,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 0,
+                      "element_type": {
+                        "id": 10,
+                        "kind_type": "BTF_KIND_PTR",
+                        "type": {
+                          "id": 11,
+                          "kind_type": "BTF_KIND_TYPEDEF",
+                          "name": "inner_map_t",
+                          "type": {
+                            "id": 12,
+                            "kind_type": "BTF_KIND_STRUCT",
+                            "size_in_bytes": 32,
+                            "members": [
+                              {
+                                "name": "type",
+                                "offset_from_start_in_bits": 0,
+                                "type": {
+                                  "id": 13,
+                                  "kind_type": "BTF_KIND_PTR",
+                                  "type": {
+                                    "id": 14,
+                                    "kind_type": "BTF_KIND_ARRAY",
+                                    "count_of_elements": 2,
+                                    "element_type": {
+                                      "id": 2,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "int",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": true,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    },
+                                    "index_type": {
+                                      "id": 4,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "__ARRAY_SIZE_TYPE__",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": false,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "name": "key",
+                                "offset_from_start_in_bits": 64,
+                                "type": {
+                                  "id": 7,
+                                  "kind_type": "BTF_KIND_PTR",
+                                  "type": {
+                                    "id": 8,
+                                    "kind_type": "BTF_KIND_TYPEDEF",
+                                    "name": "uint32_t",
+                                    "type": {
+                                      "id": 9,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "unsigned int",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": false,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "name": "value",
+                                "offset_from_start_in_bits": 128,
+                                "type": {
+                                  "id": 7,
+                                  "kind_type": "BTF_KIND_PTR",
+                                  "type": {
+                                    "id": 8,
+                                    "kind_type": "BTF_KIND_TYPEDEF",
+                                    "name": "uint32_t",
+                                    "type": {
+                                      "id": 9,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "unsigned int",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": false,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "name": "max_entries",
+                                "offset_from_start_in_bits": 192,
+                                "type": {
+                                  "id": 5,
+                                  "kind_type": "BTF_KIND_PTR",
+                                  "type": {
+                                    "id": 6,
+                                    "kind_type": "BTF_KIND_ARRAY",
+                                    "count_of_elements": 1,
+                                    "element_type": {
+                                      "id": 2,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "int",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": true,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    },
+                                    "index_type": {
+                                      "id": 4,
+                                      "kind_type": "BTF_KIND_INT",
+                                      "name": "__ARRAY_SIZE_TYPE__",
+                                      "size_in_bytes": 4,
+                                      "offset_from_start_in_bits": 0,
+                                      "field_width_in_bits": 32,
+                                      "is_signed": false,
+                                      "is_char": false,
+                                      "is_bool": false
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/mapoverflow.json
+++ b/json/mapoverflow.json
@@ -1,0 +1,183 @@
+{
+  "btf_kinds": [
+    {
+      "id": 17,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 16,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 14,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 15,
+                "kind_type": "BTF_KIND_FWD",
+                "name": "ctx",
+                "is_struct": false
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 18,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 13,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 2,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "int",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": true,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 6,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint64_t",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint64_t",
+                        "type": {
+                          "id": 9,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned long long",
+                          "size_in_bytes": 8,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 64,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 10,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 11,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/mapunderflow.json
+++ b/json/mapunderflow.json
@@ -1,0 +1,183 @@
+{
+  "btf_kinds": [
+    {
+      "id": 17,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 16,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 14,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 15,
+                "kind_type": "BTF_KIND_FWD",
+                "name": "ctx",
+                "is_struct": false
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 18,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 13,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 2,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "int",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": true,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 6,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint64_t",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint64_t",
+                        "type": {
+                          "id": 9,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned long long",
+                          "size_in_bytes": 8,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 64,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 10,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 11,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/mapvalue-overrun.json
+++ b/json/mapvalue-overrun.json
@@ -1,0 +1,181 @@
+{
+  "btf_kinds": [
+    {
+      "id": 16,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 15,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 14,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 17,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 13,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 2,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "int",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": true,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 6,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 9,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 10,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 11,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/nullmapref.json
+++ b/json/nullmapref.json
@@ -1,0 +1,191 @@
+{
+  "btf_kinds": [
+    {
+      "id": 13,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "test_repro",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 12,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 11,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 14,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 10,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "test_map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 9,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 8,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 8,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/packet_access.json
+++ b/json/packet_access.json
@@ -1,0 +1,162 @@
+{
+  "btf_kinds": [
+    {
+      "id": 7,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "test_packet_access",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 5,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 2,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name": "xdp_md",
+                "size_in_bytes": 24,
+                "members": [
+                  {
+                    "name": "data",
+                    "offset_from_start_in_bits": 0,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_end",
+                    "offset_from_start_in_bits": 32,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_meta",
+                    "offset_from_start_in_bits": 64,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "ingress_ifindex",
+                    "offset_from_start_in_bits": 96,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "rx_queue_index",
+                    "offset_from_start_in_bits": 128,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "egress_ifindex",
+                    "offset_from_start_in_bits": 160,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 6,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    }
+  ]
+}

--- a/json/packet_overflow.json
+++ b/json/packet_overflow.json
@@ -1,0 +1,162 @@
+{
+  "btf_kinds": [
+    {
+      "id": 7,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "read_write_packet_start",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 5,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 2,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name": "xdp_md",
+                "size_in_bytes": 24,
+                "members": [
+                  {
+                    "name": "data",
+                    "offset_from_start_in_bits": 0,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_end",
+                    "offset_from_start_in_bits": 32,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_meta",
+                    "offset_from_start_in_bits": 64,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "ingress_ifindex",
+                    "offset_from_start_in_bits": 96,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "rx_queue_index",
+                    "offset_from_start_in_bits": 128,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "egress_ifindex",
+                    "offset_from_start_in_bits": 160,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 6,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    }
+  ]
+}

--- a/json/packet_reallocate.json
+++ b/json/packet_reallocate.json
@@ -1,0 +1,738 @@
+{
+  "btf_kinds": [
+    {
+      "id": 16,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "reallocate_invalidates",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 14,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 2,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name": "__sk_buff",
+                "size_in_bytes": 184,
+                "members": [
+                  {
+                    "name": "len",
+                    "offset_from_start_in_bits": 0,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "pkt_type",
+                    "offset_from_start_in_bits": 32,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "mark",
+                    "offset_from_start_in_bits": 64,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "queue_mapping",
+                    "offset_from_start_in_bits": 96,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "protocol",
+                    "offset_from_start_in_bits": 128,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "vlan_present",
+                    "offset_from_start_in_bits": 160,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "vlan_tci",
+                    "offset_from_start_in_bits": 192,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "vlan_proto",
+                    "offset_from_start_in_bits": 224,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "priority",
+                    "offset_from_start_in_bits": 256,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "ingress_ifindex",
+                    "offset_from_start_in_bits": 288,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "ifindex",
+                    "offset_from_start_in_bits": 320,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "tc_index",
+                    "offset_from_start_in_bits": 352,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "cb",
+                    "offset_from_start_in_bits": 384,
+                    "type": {
+                      "id": 5,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 5,
+                      "element_type": {
+                        "id": 3,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__u32",
+                        "type": {
+                          "id": 4,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      },
+                      "index_type": {
+                        "id": 6,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "hash",
+                    "offset_from_start_in_bits": 544,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "tc_classid",
+                    "offset_from_start_in_bits": 576,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data",
+                    "offset_from_start_in_bits": 608,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_end",
+                    "offset_from_start_in_bits": 640,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "napi_id",
+                    "offset_from_start_in_bits": 672,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "family",
+                    "offset_from_start_in_bits": 704,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "remote_ip4",
+                    "offset_from_start_in_bits": 736,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "local_ip4",
+                    "offset_from_start_in_bits": 768,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "remote_ip6",
+                    "offset_from_start_in_bits": 800,
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 4,
+                      "element_type": {
+                        "id": 3,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__u32",
+                        "type": {
+                          "id": 4,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      },
+                      "index_type": {
+                        "id": 6,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "local_ip6",
+                    "offset_from_start_in_bits": 928,
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 4,
+                      "element_type": {
+                        "id": 3,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__u32",
+                        "type": {
+                          "id": 4,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      },
+                      "index_type": {
+                        "id": 6,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "remote_port",
+                    "offset_from_start_in_bits": 1056,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "local_port",
+                    "offset_from_start_in_bits": 1088,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_meta",
+                    "offset_from_start_in_bits": 1120,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "offset_from_start_in_bits": 1152,
+                    "type": {
+                      "id": 8,
+                      "kind_type": "BTF_KIND_UNION",
+                      "size_in_bytes": 8,
+                      "members": [
+                        {
+                          "name": "flow_keys",
+                          "offset_from_start_in_bits": 0,
+                          "type": {
+                            "id": 9,
+                            "kind_type": "BTF_KIND_PTR",
+                            "type": {
+                              "id": 17,
+                              "kind_type": "BTF_KIND_FWD",
+                              "name": "bpf_flow_keys",
+                              "is_struct": false
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "tstamp",
+                    "offset_from_start_in_bits": 1216,
+                    "type": {
+                      "id": 10,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u64",
+                      "type": {
+                        "id": 11,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned long long",
+                        "size_in_bytes": 8,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 64,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "wire_len",
+                    "offset_from_start_in_bits": 1280,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "gso_segs",
+                    "offset_from_start_in_bits": 1312,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "offset_from_start_in_bits": 1344,
+                    "type": {
+                      "id": 12,
+                      "kind_type": "BTF_KIND_UNION",
+                      "size_in_bytes": 8,
+                      "members": [
+                        {
+                          "name": "sk",
+                          "offset_from_start_in_bits": 0,
+                          "type": {
+                            "id": 13,
+                            "kind_type": "BTF_KIND_PTR",
+                            "type": {
+                              "id": 18,
+                              "kind_type": "BTF_KIND_FWD",
+                              "name": "bpf_sock",
+                              "is_struct": false
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "gso_size",
+                    "offset_from_start_in_bits": 1408,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 15,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    }
+  ]
+}

--- a/json/packet_start_ok.json
+++ b/json/packet_start_ok.json
@@ -1,0 +1,162 @@
+{
+  "btf_kinds": [
+    {
+      "id": 7,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "read_write_packet_start",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 5,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 2,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name": "xdp_md",
+                "size_in_bytes": 24,
+                "members": [
+                  {
+                    "name": "data",
+                    "offset_from_start_in_bits": 0,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_end",
+                    "offset_from_start_in_bits": 32,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_meta",
+                    "offset_from_start_in_bits": 64,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "ingress_ifindex",
+                    "offset_from_start_in_bits": 96,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "rx_queue_index",
+                    "offset_from_start_in_bits": 128,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "egress_ifindex",
+                    "offset_from_start_in_bits": 160,
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 6,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    }
+  ]
+}

--- a/json/prog_array.json
+++ b/json/prog_array.json
@@ -1,0 +1,345 @@
+{
+  "btf_kinds": [
+    {
+      "id": 17,
+      "kind_type": "BTF_KIND_FUNCTION",
+      "name": "func0",
+      "linkage": "BTF_LINKAGE_GLOBAL",
+      "type": {
+        "id": 16,
+        "kind_type": "BTF_KIND_FUNCTION_PROTOTYPE",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 19,
+      "kind_type": "BTF_KIND_FUNCTION",
+      "name": "func1",
+      "linkage": "BTF_LINKAGE_GLOBAL",
+      "type": {
+        "id": 18,
+        "kind_type": "BTF_KIND_FUNCTION_PROTOTYPE",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 21,
+      "kind_type": "BTF_KIND_FUNCTION",
+      "name": "func2",
+      "linkage": "BTF_LINKAGE_GLOBAL",
+      "type": {
+        "id": 20,
+        "kind_type": "BTF_KIND_FUNCTION_PROTOTYPE",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 23,
+      "kind_type": "BTF_KIND_FUNCTION",
+      "name": "func3",
+      "linkage": "BTF_LINKAGE_GLOBAL",
+      "type": {
+        "id": 22,
+        "kind_type": "BTF_KIND_FUNCTION_PROTOTYPE",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 25,
+      "kind_type": "BTF_KIND_FUNCTION",
+      "name": "func",
+      "linkage": "BTF_LINKAGE_GLOBAL",
+      "type": {
+        "id": 24,
+        "kind_type": "BTF_KIND_FUNCTION_PROTOTYPE",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 26,
+      "kind_type": "BTF_KIND_DATA_SECTION",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 56,
+          "type": {
+            "id": 15,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "prog_array_map",
+            "linkage": "BTF_LINKAGE_GLOBAL",
+            "type": {
+              "id": 14,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 24,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 3,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 8,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 9,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 4,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "values",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 13,
+                    "kind_type": "BTF_KIND_ARRAY",
+                    "count_of_elements": 0,
+                    "element_type": {
+                      "id": 10,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 11,
+                        "kind_type": "BTF_KIND_FUNCTION_PROTOTYPE",
+                        "parameters": [
+                          {
+                            "name": "",
+                            "type": {
+                              "id": 12,
+                              "kind_type": "BTF_KIND_PTR",
+                              "type": {
+                                "id": 0,
+                                "kind_type": "BTF_KIND_VOID"
+                              }
+                            }
+                          }
+                        ],
+                        "return_type": {
+                          "id": 2,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": true,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    },
+                    "index_type": {
+                      "id": 4,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "__ARRAY_SIZE_TYPE__",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": false,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/ringbuf_in_map.json
+++ b/json/ringbuf_in_map.json
@@ -1,0 +1,345 @@
+{
+  "btf_kinds": [
+    {
+      "id": 22,
+      "kind_type": "BTF_KIND_FUNCTION",
+      "name": "func",
+      "linkage": "BTF_LINKAGE_GLOBAL",
+      "type": {
+        "id": 21,
+        "kind_type": "BTF_KIND_FUNCTION_PROTOTYPE",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 20,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 23,
+      "kind_type": "BTF_KIND_DATA_SECTION",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 16,
+          "type": {
+            "id": 8,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "inner_map",
+            "linkage": "BTF_LINKAGE_GLOBAL",
+            "type": {
+              "id": 7,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 16,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 27,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 262144,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 19,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "array_of_maps",
+            "linkage": "BTF_LINKAGE_GLOBAL",
+            "type": {
+              "id": 18,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 24,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 9,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 10,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 12,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 11,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 12,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 13,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 14,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 15,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "values",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 17,
+                    "kind_type": "BTF_KIND_ARRAY",
+                    "count_of_elements": 0,
+                    "element_type": {
+                      "id": 16,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_STRUCT",
+                        "size_in_bytes": 16,
+                        "members": [
+                          {
+                            "name": "type",
+                            "offset_from_start_in_bits": 0,
+                            "type": {
+                              "id": 1,
+                              "kind_type": "BTF_KIND_PTR",
+                              "type": {
+                                "id": 3,
+                                "kind_type": "BTF_KIND_ARRAY",
+                                "count_of_elements": 27,
+                                "element_type": {
+                                  "id": 2,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "int",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": true,
+                                  "is_char": false,
+                                  "is_bool": false
+                                },
+                                "index_type": {
+                                  "id": 4,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "__ARRAY_SIZE_TYPE__",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": false,
+                                  "is_char": false,
+                                  "is_bool": false
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "name": "max_entries",
+                            "offset_from_start_in_bits": 64,
+                            "type": {
+                              "id": 5,
+                              "kind_type": "BTF_KIND_PTR",
+                              "type": {
+                                "id": 6,
+                                "kind_type": "BTF_KIND_ARRAY",
+                                "count_of_elements": 262144,
+                                "element_type": {
+                                  "id": 2,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "int",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": true,
+                                  "is_char": false,
+                                  "is_bool": false
+                                },
+                                "index_type": {
+                                  "id": 4,
+                                  "kind_type": "BTF_KIND_INT",
+                                  "name": "__ARRAY_SIZE_TYPE__",
+                                  "size_in_bytes": 4,
+                                  "offset_from_start_in_bits": 0,
+                                  "field_width_in_bits": 32,
+                                  "is_signed": false,
+                                  "is_char": false,
+                                  "is_bool": false
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "index_type": {
+                      "id": 4,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "__ARRAY_SIZE_TYPE__",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": false,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/ringbuf_uninit.json
+++ b/json/ringbuf_uninit.json
@@ -1,0 +1,133 @@
+{
+  "btf_kinds": [
+    {
+      "id": 11,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "test",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 10,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 9,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 12,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 16,
+          "type": {
+            "id": 8,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "ring_buffer",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 7,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 16,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 27,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 262144,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/stackok.json
+++ b/json/stackok.json
@@ -1,0 +1,38 @@
+{
+  "btf_kinds": [
+    {
+      "id": 4,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 2,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 3,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    }
+  ]
+}

--- a/json/tail_call.json
+++ b/json/tail_call.json
@@ -1,0 +1,473 @@
+{
+  "btf_kinds": [
+    {
+      "id": 17,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "caller",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 16,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 13,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 14,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name": "xdp_md",
+                "size_in_bytes": 24,
+                "members": [
+                  {
+                    "name": "data",
+                    "offset_from_start_in_bits": 0,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_end",
+                    "offset_from_start_in_bits": 32,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_meta",
+                    "offset_from_start_in_bits": 64,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "ingress_ifindex",
+                    "offset_from_start_in_bits": 96,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "rx_queue_index",
+                    "offset_from_start_in_bits": 128,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "egress_ifindex",
+                    "offset_from_start_in_bits": 160,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 19,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "callee",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 18,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 13,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 14,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name": "xdp_md",
+                "size_in_bytes": 24,
+                "members": [
+                  {
+                    "name": "data",
+                    "offset_from_start_in_bits": 0,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_end",
+                    "offset_from_start_in_bits": 32,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_meta",
+                    "offset_from_start_in_bits": 64,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "ingress_ifindex",
+                    "offset_from_start_in_bits": 96,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "rx_queue_index",
+                    "offset_from_start_in_bits": 128,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "egress_ifindex",
+                    "offset_from_start_in_bits": 160,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 20,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 12,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 11,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 3,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 8,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 8,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 9,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 10,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/tail_call_bad.json
+++ b/json/tail_call_bad.json
@@ -1,0 +1,473 @@
+{
+  "btf_kinds": [
+    {
+      "id": 17,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "caller",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 16,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 13,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 14,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name": "xdp_md",
+                "size_in_bytes": 24,
+                "members": [
+                  {
+                    "name": "data",
+                    "offset_from_start_in_bits": 0,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_end",
+                    "offset_from_start_in_bits": 32,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_meta",
+                    "offset_from_start_in_bits": 64,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "ingress_ifindex",
+                    "offset_from_start_in_bits": 96,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "rx_queue_index",
+                    "offset_from_start_in_bits": 128,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "egress_ifindex",
+                    "offset_from_start_in_bits": 160,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 19,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "callee",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 18,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 13,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 14,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name": "xdp_md",
+                "size_in_bytes": 24,
+                "members": [
+                  {
+                    "name": "data",
+                    "offset_from_start_in_bits": 0,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_end",
+                    "offset_from_start_in_bits": 32,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "data_meta",
+                    "offset_from_start_in_bits": 64,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "ingress_ifindex",
+                    "offset_from_start_in_bits": 96,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "rx_queue_index",
+                    "offset_from_start_in_bits": 128,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  },
+                  {
+                    "name": "egress_ifindex",
+                    "offset_from_start_in_bits": 160,
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "__u32",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "unsigned int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 20,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 12,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 11,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 8,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 8,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 9,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 10,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/twomaps.json
+++ b/json/twomaps.json
@@ -1,0 +1,340 @@
+{
+  "btf_kinds": [
+    {
+      "id": 23,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 22,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 20,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 21,
+                "kind_type": "BTF_KIND_FWD",
+                "name": "ctx",
+                "is_struct": false
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 24,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 13,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map1",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 2,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "int",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": true,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 6,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint64_t",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint64_t",
+                        "type": {
+                          "id": 9,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned long long",
+                          "size_in_bytes": 8,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 64,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 10,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 11,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 19,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map2",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 18,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key_size",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 14,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 15,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 4,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "value_size",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 16,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 17,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 8,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/twomaps_btf.json
+++ b/json/twomaps_btf.json
@@ -1,0 +1,335 @@
+{
+  "btf_kinds": [
+    {
+      "id": 22,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 21,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 19,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 20,
+                "kind_type": "BTF_KIND_FWD",
+                "name": "ctx",
+                "is_struct": false
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 23,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 12,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map1",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 11,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 2,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "int",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": true,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 6,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint64_t",
+                      "type": {
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "long unsigned int",
+                        "size_in_bytes": 8,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 64,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 9,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 10,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 18,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map2",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 17,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key_size",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 13,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 14,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 4,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "value_size",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 15,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 16,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 8,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/twostackvars.json
+++ b/json/twostackvars.json
@@ -1,0 +1,40 @@
+{
+  "btf_kinds": [
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name": "ctx",
+                "is_struct": false
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    }
+  ]
+}

--- a/json/twotypes.json
+++ b/json/twotypes.json
@@ -1,0 +1,189 @@
+{
+  "btf_kinds": [
+    {
+      "id": 15,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 14,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 12,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 13,
+                "kind_type": "BTF_KIND_FWD",
+                "name": "ctx",
+                "is_struct": false
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 16,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 11,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 10,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 2,
+                      "kind_type": "BTF_KIND_INT",
+                      "name": "int",
+                      "size_in_bytes": 4,
+                      "offset_from_start_in_bits": 0,
+                      "field_width_in_bits": 32,
+                      "is_signed": true,
+                      "is_char": false,
+                      "is_bool": false
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 6,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 7,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1024,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 8,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 9,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/wronghelper.json
+++ b/json/wronghelper.json
@@ -1,0 +1,191 @@
+{
+  "btf_kinds": [
+    {
+      "id": 15,
+      "kind_type": "BTF_KIND_FUNC",
+      "name": "func",
+      "linkage": "BTF_FUNC_GLOBAL",
+      "type": {
+        "id": 14,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters": [
+          {
+            "name": "ctx",
+            "type": {
+              "id": 13,
+              "kind_type": "BTF_KIND_PTR",
+              "type": {
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type": {
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name": "int",
+          "size_in_bytes": 4,
+          "offset_from_start_in_bits": 0,
+          "field_width_in_bits": 32,
+          "is_signed": true,
+          "is_char": false,
+          "is_bool": false
+        }
+      }
+    },
+    {
+      "id": 16,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name": ".maps",
+      "size": 0,
+      "members": [
+        {
+          "offset": 0,
+          "size": 32,
+          "type": {
+            "id": 12,
+            "kind_type": "BTF_KIND_VAR",
+            "name": "map",
+            "linkage": "BTF_LINKAGE_STATIC",
+            "type": {
+              "id": 11,
+              "kind_type": "BTF_KIND_STRUCT",
+              "size_in_bytes": 32,
+              "members": [
+                {
+                  "name": "type",
+                  "offset_from_start_in_bits": 0,
+                  "type": {
+                    "id": 1,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 3,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 2,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "key",
+                  "offset_from_start_in_bits": 64,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 8,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "value",
+                  "offset_from_start_in_bits": 128,
+                  "type": {
+                    "id": 5,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 6,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name": "uint32_t",
+                      "type": {
+                        "id": 7,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name": "__uint32_t",
+                        "type": {
+                          "id": 8,
+                          "kind_type": "BTF_KIND_INT",
+                          "name": "unsigned int",
+                          "size_in_bytes": 4,
+                          "offset_from_start_in_bits": 0,
+                          "field_width_in_bits": 32,
+                          "is_signed": false,
+                          "is_char": false,
+                          "is_bool": false
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "max_entries",
+                  "offset_from_start_in_bits": 192,
+                  "type": {
+                    "id": 9,
+                    "kind_type": "BTF_KIND_PTR",
+                    "type": {
+                      "id": 10,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "count_of_elements": 1,
+                      "element_type": {
+                        "id": 2,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "int",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": true,
+                        "is_char": false,
+                        "is_bool": false
+                      },
+                      "index_type": {
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name": "__ARRAY_SIZE_TYPE__",
+                        "size_in_bytes": 4,
+                        "offset_from_start_in_bits": 0,
+                        "field_width_in_bits": 32,
+                        "is_signed": false,
+                        "is_char": false,
+                        "is_bool": false
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/libbtf/btf_map.cpp
+++ b/libbtf/btf_map.cpp
@@ -75,32 +75,16 @@ static bool _is_map_type(const btf_type_data &btf_types,
   auto map_struct = btf_types.get_kind_type<btf_kind_struct>(map_type_id);
   bool has_type = false;
   bool has_max_entries = false;
-  bool has_key = false;
-  bool has_key_size = false;
-  bool has_value = false;
-  bool has_value_size = false;
-  bool has_values = false;
 
   for (const auto &member : map_struct.members) {
     if (member.name == "type") {
       has_type = true;
     } else if (member.name == "max_entries") {
       has_max_entries = true;
-    } else if (member.name == "key") {
-      has_key = true;
-    } else if (member.name == "key_size") {
-      has_key_size = true;
-    } else if (member.name == "value") {
-      has_value = true;
-    } else if (member.name == "value_size") {
-      has_value_size = true;
-    } else if (member.name == "values") {
-      has_values = true;
     }
   }
 
-  return has_type && has_max_entries && (has_key || has_key_size) &&
-         (has_value || has_value_size || has_values);
+  return has_type && has_max_entries;
 }
 
 /**

--- a/libbtf/btf_map.cpp
+++ b/libbtf/btf_map.cpp
@@ -58,8 +58,6 @@ static btf_type_id _unwrap_type(const btf_type_data &btf_types,
  * is a struct with the following members:
  * - type
  * - max_entries
- * - key or key_size
- * - value or value_size or values
  *
  * @param btf_types The BTF types object.
  * @param map_type_id The type id of the type to check.

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -41,7 +41,7 @@ std::map<std::string, std::string> string_replacements = {
 
 #define TEST_OBJECT_FILE_DIRECTORY "external/ebpf-samples/build/"
 #define TEST_SOURCE_FILE_DIRECTORY "external/ebpf-samples/src/"
-#define TEST_JSON_FILE_DIRECTORY "external/ebpf-samples/json/"
+#define TEST_JSON_FILE_DIRECTORY "json/"
 #define TEST_C_HEADER_FILE_DIRECTORY "test/expected/"
 #define BTF_CASE(file, apply_replacements)                                     \
   TEST_CASE("BTF JSON suite: " file, "[json]") {                               \


### PR DESCRIPTION
Resolves: #110 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the subproject reference for `external/ebpf-samples` to the latest commit.
	- Added a new test case for BPF Type Format (BTF) map functionality, enhancing test coverage for ring buffers.

- **Bug Fixes**
	- Simplified logic in the map type validation, potentially improving performance and reliability in determining valid map types. 

- **Documentation**
	- Clarified implications of changes to map type checks for better understanding of functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->