### PR TITLE
Parse global variables

### DIFF
--- a/libbtf/btf_map.h
+++ b/libbtf/btf_map.h
@@ -33,6 +33,18 @@ std::vector<btf_map_definition>
 parse_btf_map_section(const btf_type_data &btf_data);
 
 /**
+ * @brief Extract BTF map definitions for global variables from a
+ * BTF_KIND_DATA_SECTION section with name "section_name".
+ *
+ * @param[in] btf_data BTF data.
+ * @param[in] section_name Name of the section to parse.
+ * @return std::vector<btf_map_definition>
+ */
+std::vector<btf_map_definition>
+parse_btf_variable_section(const btf_type_data &btf_data,
+                           const std::string &section_name);
+
+/**
  * @brief Add a BTF_KIND_DATA_SECTION section with name ".maps" to a collection
  * of BTF data.
  *


### PR DESCRIPTION
This pull request introduces a new function to parse BTF variable sections and includes related updates to the codebase and tests. The most important changes include adding the `parse_btf_variable_section` function to `libbtf`, updating the header file with the new function's declaration, and adding a test case for this new functionality.

Enhancements to BTF parsing:

* [`libbtf/btf_map.cpp`](diffhunk://#diff-90dff7da2aa615a938a2d39d56f698c6aed3f70c0ceb0781b49c4ead4561c07bR189-R218): Added the `parse_btf_variable_section` function to extract BTF map definitions for global variables from a BTF_KIND_DATA_SECTION section.

Updates to header files:

* [`libbtf/btf_map.h`](diffhunk://#diff-9ef652776efc645e4f1fdc515eee098a1dc951f423f6d6613906ee715298b7baR35-R46): Added the declaration of the `parse_btf_variable_section` function, including a brief documentation comment.

Testing improvements:

* [`test/test.cpp`](diffhunk://#diff-ea13c4b53c26f8e963a64f40a86710bacc1e1097ef024f6e2b2391ffcbb9d262R783-R831): Added a new test case `build_btf_map_section_for_globals` to validate the functionality of the `parse_btf_variable_section` function.

Subproject updates:

* [`external/ebpf-samples`](diffhunk://#diff-baa225d36a15935618dd1037ddeed3ac020ea4fda2e2f5202737188365c510edL1-R1): Updated the subproject commit to the latest version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to extract BTF map definitions from global variables.
- **Bug Fixes**
	- Added a test case to verify the parsing of BTF map definitions for global variables, ensuring accuracy in functionality.
- **Chores**
	- Updated subproject commit identifier for `external/ebpf-samples`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->