### PR TITLE
Parse .bss, .data, and .rodata into array maps

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -780,3 +780,43 @@ TEST_CASE("build_btf_map_section", "[btf_type_data]") {
   REQUIRE(generated_map_definitions[0].inner_map_type_id ==
           generated_map_definitions[1].type_id);
 }
+
+TEST_CASE("parse_btf_map_section_globals", "[btf_type_data]") {
+  auto reader = ELFIO::elfio();
+  std::string file = "global_variable";
+  REQUIRE(reader.load(std::string(TEST_OBJECT_FILE_DIRECTORY) + file + ".o"));
+
+  auto btf = reader.sections[".BTF"];
+
+  libbtf::btf_type_data btf_data = std::vector<std::byte>(
+      {reinterpret_cast<const std::byte *>(btf->get_data()),
+       reinterpret_cast<const std::byte *>(btf->get_data() + btf->get_size())});
+
+  auto map_definitions = libbtf::parse_btf_map_section(btf_data);
+
+  REQUIRE(map_definitions.size() == 3);
+  REQUIRE(map_definitions[0].name == ".bss");
+  REQUIRE(map_definitions[0].type_id == 15);
+  REQUIRE(map_definitions[0].map_type == 0); // Undefined type
+  REQUIRE(map_definitions[0].key_size == 4);
+  REQUIRE(map_definitions[0].value_size == 8);
+  REQUIRE(map_definitions[0].max_entries == 1);
+  REQUIRE(map_definitions[0].inner_map_type_id == 0);
+
+  REQUIRE(map_definitions[1].name == ".data");
+  REQUIRE(map_definitions[1].type_id == 16);
+  REQUIRE(map_definitions[1].map_type == 0); // Undefined type
+  REQUIRE(map_definitions[1].key_size == 4);
+  REQUIRE(map_definitions[1].value_size == 40);
+  REQUIRE(map_definitions[1].max_entries == 1);
+  REQUIRE(map_definitions[1].inner_map_type_id == 0);
+
+  REQUIRE(map_definitions[2].name == ".rodata");
+  REQUIRE(map_definitions[2].type_id == 17);
+  REQUIRE(map_definitions[2].map_type == 0); // Undefined type
+  REQUIRE(map_definitions[2].key_size == 4);
+  REQUIRE(map_definitions[2].value_size == 4);
+  REQUIRE(map_definitions[2].max_entries == 1);
+  REQUIRE(map_definitions[2].inner_map_type_id == 0);
+
+}


### PR DESCRIPTION
This pull request includes several changes to the `libbtf` library and its tests, as well as an update to the `external/ebpf-samples` submodule. The most important changes involve adding support for parsing global variables in BTF map sections and updating the corresponding tests.

Enhancements to BTF map parsing:

* [`libbtf/btf_map.cpp`](diffhunk://#diff-90dff7da2aa615a938a2d39d56f698c6aed3f70c0ceb0781b49c4ead4561c07bR192-R195): Added logic to handle `.bss`, `.data`, and `.rodata` sections when parsing BTF map sections. This includes creating maps for these sections if they exist and adding them to the map definitions. [[1]](diffhunk://#diff-90dff7da2aa615a938a2d39d56f698c6aed3f70c0ceb0781b49c4ead4561c07bR192-R195) [[2]](diffhunk://#diff-90dff7da2aa615a938a2d39d56f698c6aed3f70c0ceb0781b49c4ead4561c07bR233-R261)

Updates to tests:

* [`test/test.cpp`](diffhunk://#diff-ea13c4b53c26f8e963a64f40a86710bacc1e1097ef024f6e2b2391ffcbb9d262R783-R822): Added a new test case `parse_btf_map_section_globals` to verify the parsing of global variables in BTF map sections. This test ensures that the `.bss`, `.data`, and `.rodata` sections are correctly parsed and their attributes are validated.

Submodule update:

* [`external/ebpf-samples`](diffhunk://#diff-baa225d36a15935618dd1037ddeed3ac020ea4fda2e2f5202737188365c510edL1-R1): Updated the submodule commit to the latest version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new test case for parsing BTF map sections with global variables
	- Enhanced map section parsing with more robust handling of data sections

- **Chores**
	- Updated external eBPF samples subproject to a new commit

- **Bug Fixes**
	- Improved handling of map definitions and section parsing logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->