### PR TITLE
Add check for empty data sections.

### DIFF
--- a/libbtf/btf_map.cpp
+++ b/libbtf/btf_map.cpp
@@ -236,6 +236,9 @@ parse_btf_map_section(const btf_type_data &btf_data) {
   auto handle_data_section = [&](btf_type_id data_section_id) {
     auto data_section =
         btf_data.get_kind_type<btf_kind_data_section>(data_section_id);
+    if (data_section.members.empty()) { // Skip empty data sections.
+      return;
+    }
     btf_map_definition map_definition = {};
     map_definition.name = data_section.name;
     map_definition.type_id = data_section_id;


### PR DESCRIPTION
Adds a check for empty data sections to prevent a crash on line 246 (call to `.back()`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved error handling for map parsing by adding a check to skip processing empty data sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->