### PR TITLE
Make loop detection in libbtf parser optional

### DIFF
--- a/libbtf/btf_type_data.cpp
+++ b/libbtf/btf_type_data.cpp
@@ -15,7 +15,7 @@
 
 namespace libbtf {
 
-btf_type_data::btf_type_data(const std::vector<std::byte> &btf_data) {
+btf_type_data::btf_type_data(const std::vector<std::byte> &btf_data, bool reject_cycles) {
   auto visitor = [&, this](btf_type_id id,
                            const std::optional<std::string> &name,
                            const btf_kind &kind) {
@@ -25,10 +25,14 @@ btf_type_data::btf_type_data(const std::vector<std::byte> &btf_data) {
     }
   };
   btf_parse_types(btf_data, visitor);
-  // Validate that the type graph is valid.
-  for (const auto &[id, kind] : id_to_kind) {
-    std::set<btf_type_id> visited;
-    validate_type_graph(id, visited);
+  // If reject_cycles is true, validate the type graph.
+  // This will throw an exception if there are cycles.
+  if (reject_cycles) {
+    // Validate that the type graph is valid.
+    for (const auto &[id, kind] : id_to_kind) {
+      std::set<btf_type_id> visited;
+      validate_type_graph(id, visited);
+    }
   }
 }
 

--- a/libbtf/btf_type_data.h
+++ b/libbtf/btf_type_data.h
@@ -42,8 +42,12 @@ public:
    * @brief Construct a new btf type data object from a vector of bytes.
    *
    * @param[in] btf_data The BTF data.
+   * @param[in] reject_cycles If true, reject cycles in the type graph.
+   * @throws std::runtime_error If the BTF data is invalid or if there are
+   * cycles in the type graph.
    */
-  btf_type_data(const std::vector<std::byte> &btf_data);
+  btf_type_data(const std::vector<std::byte> &btf_data,
+                bool reject_cycles = true);
 
   /**
    * @brief Destroy the btf type data object


### PR DESCRIPTION
Resolves: #144 

Make loop detection in libbtf parser optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to control whether cycles in type graphs are rejected during data processing.

- **Documentation**
  - Updated documentation to describe the new option for cycle detection and its effect on error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->