### PR TITLE
Fix MacOS build - remove redundant cmake install

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -49,7 +49,6 @@ jobs:
       if: inputs.platform == 'macos-latest'
       run: |
         brew install \
-          cmake \
           ninja \
           ccache
 


### PR DESCRIPTION
This pull request makes a small change to the build workflow configuration. The change removes the installation of `cmake` from the list of Homebrew packages installed on macOS runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined macOS build prerequisites by removing an unnecessary dependency to reduce setup overhead and improve CI efficiency. Remaining tools continue to be installed as before.
  * Enhances build pipeline reliability and performance with no impact on application functionality or user experience.
  * No changes to public APIs or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->